### PR TITLE
Attempt Patch for Issue #9

### DIFF
--- a/src/django_saml2_pro_auth/views.py
+++ b/src/django_saml2_pro_auth/views.py
@@ -49,7 +49,7 @@ def saml_login(request):
             raise SAMLError('ERRORS FOUND IN SAML REQUEST: %s' % errors)
     elif 'provider' in req['get_data']:
         if hasattr(settings, 'SAML_REDIRECT'):
-            return HttpResponseRedirect(auth.login(settings.SAML_REDIRECT))
+            return HttpResponseRedirect(auth.login(return_to=settings.SAML_REDIRECT))
         elif 'RelayState' in req['post_data']:
                 return HttpResponseRedirect(auth.redirect_to(req['post_data']['RelayState']))
         else:


### PR DESCRIPTION
For https://github.com/MindPointGroup/django-saml2-pro-auth/issues/9

After looking at the python3-saml package it seems I missed a kwarg to support redirects see; https://github.com/onelogin/python3-saml/blob/07bb2ba245d3aebbd24c808a1823b12645f4d755/src/onelogin/saml2/auth.py#L321

This is an attempt to fix the issue.