### PR TITLE
Changed get_or_create to update_or_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ SAML_PROVIDERS = [{
             "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified",
             ## For the cert/key you can place their content in
             ## the x509cert and privateKey params
-            ## as single-line strings or place them in 
-            ## certs/sp.key and certs/sp.crt or you can supply a 
+            ## as single-line strings or place them in
+            ## certs/sp.key and certs/sp.crt or you can supply a
             ## path via custom_base_path which should contain
             ## sp.crt and sp.key
             "x509cert": "",
@@ -199,7 +199,27 @@ SAML_USERS_MAP = [{
     }
 ```
 
+**SAML_USERS_LOOKUP_ATTRIBUTE (optional):**
+Specifies the User model field to be used for object lookup in the database.
+Has to be one of the dict keys for the Django's User model specified in "SAML_USERS_MAP".
 
+The attribute in the Django User model should have the "unique" flag set.
+(In the default User model in django only username has a unique contstraint in the DB, the same email could be used by multiple users)
+
+Defaults to "username"
+
+```python
+SAML_USERS_LOOKUP_ATTRIBUTE = "email"
+```
+
+**SAML_USERS_SYNC_ATTRIBUTES (optional):**
+Specifies if the user attributes have to be updated at each login with those received from the IdP.
+
+Defaults to False
+
+```python
+SAML_USERS_SYNC_ATTRIBUTES = True
+```
 
 **SAML_PROVIDERS:** This is exactly the same spec as OneLogin's [python-saml and python3-saml packages](https://github.com/onelogin/python3-saml#settings). The big difference is here you supply a list of dicts where the top most key(s) must map 1:1 to the top most keys in `SAML_USERS_MAP`. Also, this package allows you to ref the cert/key files via `open()` calls. This is to allow those of you with multiple external customers to login to your platform with any N number of IdPs.
 
@@ -221,7 +241,7 @@ The following are things that you may run into issue with. Here are some tips.
 
 # Wishlist and TODOs
 
-The following are things that arent present yet but would be cool to have 
+The following are things that arent present yet but would be cool to have
 
 * Implement logic for Single Logout Service
 * ADFS IdP support

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -61,7 +61,7 @@ class Backend(object): # pragma: no cover
             lookup_attribute: final_map[lookup_attribute]
         }
 
-        user, _ = User.objects.update_or_create(**lookup_map, defaults=final_map)
+        user, _ = User.objects.update_or_create(defaults=final_map, **lookup_map)
         return user
 
     def get_user(self, user_id):

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -54,7 +54,7 @@ class Backend(object): # pragma: no cover
 
 
 
-        user, _ = User.objects.get_or_create(**final_map)
+        user, _ = User.objects.update_or_create(**final_map)
         return user
 
     def get_user(self, user_id):

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -52,7 +52,11 @@ class Backend(object): # pragma: no cover
 
         final_map = get_clean_map(user_map, request.session['samlUserdata'])
 
-        lookup_attribute = settings.SAML_USERS_LOOKUP_ATTRIBUTE
+        try:
+            lookup_attribute = settings.SAML_USERS_LOOKUP_ATTRIBUTE
+        except AttributeError:
+            lookup_attribute = "username"
+
         lookup_map = {
             lookup_attribute: final_map[lookup_attribute]
         }

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -50,11 +50,14 @@ class Backend(object): # pragma: no cover
         provider, provider_index = get_provider_index(request)
         user_map = settings.SAML_USERS_MAP[provider_index][provider]
 
-        final_map = get_clean_map(user_map, request.session['samlUserdata']) 
+        final_map = get_clean_map(user_map, request.session['samlUserdata'])
 
+        lookup_attribute = settings.SAML_USERS_LOOKUP_ATTRIBUTE
+        lookup_map = {
+            lookup_attribute: final_map[lookup_attribute]
+        }
 
-
-        user, _ = User.objects.update_or_create(**final_map)
+        user, _ = User.objects.update_or_create(**lookup_map, defaults=final_map)
         return user
 
     def get_user(self, user_id):


### PR DESCRIPTION
Changed get_or_create to update_or_create, this way if an attribute is changed on the IdP (eg. email/first_name/phone number) the user object and profiles if existing are automatically updated. As is now if they change the lookup fails and therefore get_or_create tries to create a user object but incurs in an IntegrityError on the username field.

I don't know if I'm using in some way the library wrong, but it seems to me that only one attribute should be used to lookup the user object and all the others should be updated if needed, but not used to filter the objects.

I wasn't able to test the edit now, will try asap.