### PR TITLE
Fix to avoid KeyError at /sso/saml/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Pycharm
+.idea/

--- a/README.md
+++ b/README.md
@@ -224,8 +224,9 @@ SAML_USERS_SYNC_ATTRIBUTES = True
 
 **SAML_USERS_STRICT_MAPPING (optional):**
 Specifies if every user attribute defined in SAML_USER_MAP must be present
-in the saml response or not. If set to False, make sure the user model have
- the atributes that may not be present in the response with null=True or a default value.
+in the saml response or not. If set to False, ensure your Django user model
+defines those attributes which your IdP doesn't expose in the SAML response.
+You could do this by setting null=True or a default value in your user model.
 
 Defaults to True
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,18 @@ Defaults to False
 SAML_USERS_SYNC_ATTRIBUTES = True
 ```
 
+
+**SAML_USERS_STRICT_MAPPING (optional):**
+Specifies if every user attribute defined in SAML_USER_MAP must be present
+in the saml response or not. If set to False, make sure the user model have
+ the atributes that may not be present in the response with null=True or a default value.
+
+Defaults to True
+
+```python
+SAML_USERS_STRICT_MAPPING = False
+```
+
 **SAML_PROVIDERS:** This is exactly the same spec as OneLogin's [python-saml and python3-saml packages](https://github.com/onelogin/python3-saml#settings). The big difference is here you supply a list of dicts where the top most key(s) must map 1:1 to the top most keys in `SAML_USERS_MAP`. Also, this package allows you to ref the cert/key files via `open()` calls. This is to allow those of you with multiple external customers to login to your platform with any N number of IdPs.
 
 

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -33,19 +33,25 @@ def get_provider_index(request):
 
 def get_clean_map(user_map, saml_data):
     final_map = dict()
-    for usr_k, usr_v in iteritems(user_map):
-        if type(usr_v) is dict:
+    strict_mapping = getattr(settings, "SAML_USERS_STRICT_MAPPING", True)
 
-            if usr_v['key'] in saml_data:
+    for usr_k, usr_v in iteritems(user_map):
+        if strict_mapping:
+            if type(usr_v) is dict:
                 if 'index' in usr_v:
                     final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']]
                 else:
                     final_map[usr_k] = saml_data[usr_v['key']]
             else:
-                final_map[usr_k] = None
-
+                final_map[usr_k] = saml_data[user_map[usr_k]]
         else:
-            final_map[usr_k] = saml_data[user_map[usr_k]] if user_map[usr_k] in saml_data else None
+            if type(usr_v) is dict:
+                if 'index' in usr_v:
+                    final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']] if usr_v['key'] in saml_data else None
+                else:
+                    final_map[usr_k] = saml_data[usr_v['key']] if usr_v['key'] in saml_data else None
+            else:
+                final_map[usr_k] = saml_data[user_map[usr_k]] if user_map[usr_k] in saml_data else None
 
     return final_map
 

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -30,17 +30,22 @@ def get_provider_index(request):
 
     raise SAMLError("The provider: %s was not found in settings.py" % provider)
 
+
 def get_clean_map(user_map, saml_data):
     final_map = dict()
     for usr_k, usr_v in iteritems(user_map):
         if type(usr_v) is dict:
 
-            if 'index' in usr_v:
-                final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']]
+            if usr_v['key'] in saml_data:
+                if 'index' in usr_v:
+                    final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']]
+                else:
+                    final_map[usr_k] = saml_data[usr_v['key']]
             else:
-                final_map[usr_k] = saml_data[usr_v['key']]
+                final_map[usr_k] = None
+
         else:
-            final_map[usr_k] = saml_data[ user_map[usr_k] ]
+            final_map[usr_k] = saml_data[user_map[usr_k]] if user_map[usr_k] in saml_data else None
 
     return final_map
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -108,3 +108,78 @@ class TestAuth(TestCase):
         self.assertEqual(merged_map['email'], 'montypython@example.com')
         self.assertEqual(merged_map['name'], 'montypython')
         self.assertEqual(merged_map['customer'], 'examplecorp')
+
+    @override_settings(SAML_USERS_STRICT_MAPPING=False)
+    def test_non_strict_mapping_users_with_index_values(self):
+        user_map = {
+            'email': {
+                'index': 0,
+                'key': 'Email'
+            },
+            'name': {
+                'index': 0,
+                'key': 'Username'
+            },
+            'age': {
+                'index': 0,
+                'key': 'Age'
+            }
+        }
+
+        saml_map = {
+            'Username': ['montypython'],
+            'lastName': ['Cleese'],
+            'Email': ['montypython@example.com'],
+            'firstName': ['John']
+        }
+
+        merged_map = get_clean_map(user_map, saml_map)
+        self.assertEqual(merged_map['email'], 'montypython@example.com')
+        self.assertEqual(merged_map['name'], 'montypython')
+        self.assertIsNone(merged_map['age'])
+
+    @override_settings(SAML_USERS_STRICT_MAPPING=False)
+    def test_non_strict_mapping_users_without_index_values(self):
+        user_map = {
+            'email': 'Email',
+            'name': 'Username',
+            'age': 'Age',
+        }
+
+        saml_map = {
+            'Username': 'montypython',
+            'lastName': 'Cleese',
+            'Email': 'montypython@example.com',
+            'firstName': 'John'
+        }
+
+        merged_map = get_clean_map(user_map, saml_map)
+        self.assertEqual(merged_map['email'], 'montypython@example.com')
+        self.assertEqual(merged_map['name'], 'montypython')
+        self.assertIsNone(merged_map['age'])
+
+    @override_settings(SAML_USERS_STRICT_MAPPING=False)
+    def test_non_strict_mapping_users_with_mixed_value_styles(self):
+        user_map = {
+            'email': 'Email',
+            'name': {
+                'index': 1,
+                'key': 'Username'
+            },
+            'customer': {'key': 'Client'},
+            'age': 'Age',
+        }
+
+        saml_map = {
+            'Username': ['','montypython'],
+            'lastName': 'Cleese',
+            'Email': 'montypython@example.com',
+            'firstName': 'John',
+            'Client': 'examplecorp'
+        }
+
+        merged_map = get_clean_map(user_map, saml_map)
+        self.assertEqual(merged_map['email'], 'montypython@example.com')
+        self.assertEqual(merged_map['name'], 'montypython')
+        self.assertEqual(merged_map['customer'], 'examplecorp')
+        self.assertIsNone(merged_map['age'])


### PR DESCRIPTION
Added if to control the existence of the key in dict saml_data inside. In this way, if there are fields that are not returned by the server the application still works (provided that the inexistent keys have a default in the model)