### PR TITLE
add default attribute value when strict is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ You'll want to find the equivalent on your OS of choice.
 
 **Python 2**
 
-```
+```bash
   pip install django-saml2-pro-auth
 ```
 
 **Python 3**
 
-```
+```bash
   pip3 install django-saml2-pro-auth
 ```
 
@@ -226,14 +226,30 @@ SAML_USERS_SYNC_ATTRIBUTES = True
 
 **SAML_USERS_STRICT_MAPPING (optional):**
 Specifies if every user attribute defined in SAML_USER_MAP must be present
-in the saml response or not. If set to False, you can specify a default
-value in the "SAML_USER_MAP" dict in case the attribute is not set in the
-IdP response.
+in the saml response or not.
 
 Defaults to True
 
 ```python
 SAML_USERS_STRICT_MAPPING = False
+```
+
+If set to False, you can optionally specify a default value in the "SAML_USER_MAP"
+dict and it will set the value when the attribute is not present in the IdP response object.
+
+Example default value setting
+
+```python
+# set default value for is_superuser and is_staff to False
+SAML_USERS_STRICT_MAPPING = False
+SAML_USERS_MAP = [{
+    "MyProvider" : {
+      "email": dict(key="email", index=0),
+      "username": dict(key="username", index=0),
+      "is_superuser": dict(key="is_superuser", index=0, default=False),
+      "is_staff": dict(key="is_staff", index=0, default=False)
+    }
+}]
 ```
 
 **SAML_PROVIDERS:** This is exactly the same spec as OneLogin's [python-saml and python3-saml packages](https://github.com/onelogin/python3-saml#settings). The big difference is here you supply a list of dicts where the top most key(s) must map 1:1 to the top most keys in `SAML_USERS_MAP`. Also, this package allows you to ref the cert/key files via `open()` calls. This is to allow those of you with multiple external customers to login to your platform with any N number of IdPs.

--- a/README.md
+++ b/README.md
@@ -226,9 +226,9 @@ SAML_USERS_SYNC_ATTRIBUTES = True
 
 **SAML_USERS_STRICT_MAPPING (optional):**
 Specifies if every user attribute defined in SAML_USER_MAP must be present
-in the saml response or not. If set to False, ensure your Django user model
-defines those attributes which your IdP doesn't expose in the SAML response.
-You could do this by setting null=True or a default value in your user model.
+in the saml response or not. If set to False, you can specify a default
+value in the "SAML_USER_MAP" dict in case the attribute is not set in the
+IdP response.
 
 Defaults to True
 

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -47,9 +47,9 @@ def get_clean_map(user_map, saml_data):
         else:
             if type(usr_v) is dict:
                 if 'index' in usr_v:
-                    final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']] if usr_v['key'] in saml_data else None
+                    final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']] if usr_v['key'] in saml_data else usr_v['default'] if 'default' in usr_v.keys() else None
                 else:
-                    final_map[usr_k] = saml_data[usr_v['key']] if usr_v['key'] in saml_data else None
+                    final_map[usr_k] = saml_data[usr_v['key']] if usr_v['key'] in saml_data else usr_v['default'] if 'default' in usr_v.keys() else None
             else:
                 final_map[usr_k] = saml_data[user_map[usr_k]] if user_map[usr_k] in saml_data else None
 

--- a/src/django_saml2_pro_auth/auth.py
+++ b/src/django_saml2_pro_auth/auth.py
@@ -38,7 +38,9 @@ def get_clean_map(user_map, saml_data):
     for usr_k, usr_v in iteritems(user_map):
         if strict_mapping:
             if type(usr_v) is dict:
-                if 'index' in usr_v:
+                if 'default' in usr_v.keys():
+                    raise SAMLSettingsError('A default value is set for key %s in SAML_USER_MAP while SAML_USERS_STRICT_MAPPING is activated' % usr_k)
+                if 'index' in usr_v.keys():
                     final_map[usr_k] = saml_data[usr_v['key']][usr_v['index']]
                 else:
                     final_map[usr_k] = saml_data[usr_v['key']]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -108,6 +108,28 @@ class TestAuth(TestCase):
         self.assertEqual(merged_map['email'], 'montypython@example.com')
         self.assertEqual(merged_map['name'], 'montypython')
         self.assertEqual(merged_map['customer'], 'examplecorp')
+    
+    
+    def test_mapping_users_with_default_values(self):
+        user_map = {
+            'email': 'Email',
+            'name': {
+                'index': 1,
+                'key': 'Username',
+                'default': 'testUsername'
+            },
+            'customer': {'key': 'Client', 'default': 'testClient'}
+        }
+
+        saml_map = {
+            'Username': ['','montypython'],
+            'lastName': 'Cleese',
+            'Email': 'montypython@example.com',
+            'firstName': 'John',
+            'Client': 'examplecorp'
+        }
+
+        self.assertRaises(SAMLSettingsError, get_clean_map, user_map, saml_map)
 
     @override_settings(SAML_USERS_STRICT_MAPPING=False)
     def test_non_strict_mapping_users_with_index_values(self):
@@ -183,3 +205,26 @@ class TestAuth(TestCase):
         self.assertEqual(merged_map['name'], 'montypython')
         self.assertEqual(merged_map['customer'], 'examplecorp')
         self.assertIsNone(merged_map['age'])
+
+    @override_settings(SAML_USERS_STRICT_MAPPING=False)
+    def test_non_strict_mapping_users_with_default_value(self):
+        user_map = {
+            "email": { 'key': 'Email' },
+            "name": { 'key': 'Username', 'index': 1 },
+            "is_superuser": { 'key': 'is_superuser', 'default': False },
+            "is_staff": { 'key': 'is_staff', 'default': True }
+        }
+
+        saml_map = {
+            'Username': ['','montypython'],
+            'lastName': 'Cleese',
+            'Email': 'montypython@example.com',
+            'firstName': 'John',
+            'Client': 'examplecorp'
+        }
+
+        merged_map = get_clean_map(user_map, saml_map)
+        self.assertEqual(merged_map['email'], 'montypython@example.com')
+        self.assertEqual(merged_map['name'], 'montypython')
+        self.assertEqual(merged_map['is_superuser'], False)
+        self.assertEqual(merged_map['is_staff'], True)


### PR DESCRIPTION
To avoid model modification or creation of a custom model to handle default value, I added a simple option to the attribute map dictionary when `SAML_USERS_STRICT_MAPPING = False`
allowing something like:

```python
SAML_USERS_SYNC_ATTRIBUTES = True
SAML_USERS_STRICT_MAPPING = False
SAML_USERS_MAP = [{
    "MyProvider" : {
      "email": dict(key="email", index=0),
      "username": dict(key="username", index=0),
      "is_superuser": dict(key="is_superuser", index=0, default=False),
      "is_staff": dict(key="is_staff", index=0, default=False)
    }
}]
```
