### PR TITLE
fix prepare_django_request to use get_host

### DIFF
--- a/src/django_saml2_pro_auth/utils.py
+++ b/src/django_saml2_pro_auth/utils.py
@@ -50,7 +50,7 @@ def init_saml_auth(req):
 
 
 def prepare_django_request(request):
-    http_host = request.META.get('HTTP_HOST', None)
+    http_host = request.get_host()
 
     if 'HTTP_X_FORWARDED_FOR' in request.META:
         server_port = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,5 +13,7 @@ def init_test_settings():
                 'ENGINE': 'django.db.backends.sqlite3',
                 'NAME': 'testingdb'
             }
-        }
+        },
+
+        'ALLOWED_HOSTS': ['testserver', 'example.com'],
     }


### PR DESCRIPTION
Fixes prepare_django_request to use request.get_host() instead of
directly accessing the Host HTTP header. Fixes #30