### PR TITLE
Fix URL error on new versions of Django

### DIFF
--- a/src/django_saml2_pro_auth/urls.py
+++ b/src/django_saml2_pro_auth/urls.py
@@ -8,6 +8,8 @@ from django.conf import settings
 
 from . import views
 
+app_name = 'django_saml2_pro_auth'
+
 SAML_ROUTE = getattr(settings, 'SAML_ROUTE', 'sso/saml')
 
 if SAML_ROUTE.strip()[-1] == '/':


### PR DESCRIPTION
The Django versions lower than 1.11 has the attribute `app_name` as a [function argument](https://docs.djangoproject.com/en/1.11/ref/urls/#include), but recent versions of Django [doesn't include the parameter](https://docs.djangoproject.com/en/3.0/ref/urls/#include), which causes the error:

```
Specifying a namespace in include() without providing an app_name is not supported
```

When the Django SAML 2 Pro Auth URLs are set in the project.